### PR TITLE
chore: set up monorepo skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,122 @@
+# ──────────────────────────────────────────────
+# macOS
+# ──────────────────────────────────────────────
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# ──────────────────────────────────────────────
+# IntelliJ IDEA / Android Studio
+# ──────────────────────────────────────────────
+.idea/
+*.iml
+*.ipr
+*.iws
+out/
+.idea_modules/
+
+# ──────────────────────────────────────────────
+# Visual Studio Code
+# ──────────────────────────────────────────────
+.vscode/
+*.code-workspace
+.history/
+
+# ──────────────────────────────────────────────
+# Kotlin / JVM / Gradle
+# ──────────────────────────────────────────────
+build/
+.gradle/
+gradle-app.setting
+!gradle-wrapper.jar
+!gradle-wrapper.properties
+*.class
+*.jar
+*.war
+*.ear
+*.nar
+hs_err_pid*
+replay_pid*
+
+# Spring Boot
+HELP.md
+
+# ──────────────────────────────────────────────
+# Android
+# ──────────────────────────────────────────────
+android/local.properties
+android/*.keystore
+android/*.jks
+android/captures/
+android/.externalNativeBuild/
+android/.cxx/
+android/app/release/
+
+# ──────────────────────────────────────────────
+# Python
+# ──────────────────────────────────────────────
+__pycache__/
+*.py[cod]
+*$py.class
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+.venv/
+ENV/
+pip-log.txt
+pip-delete-this-directory.txt
+.tox/
+.coverage
+.coverage.*
+htmlcov/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+dist/
+*.egg-info/
+*.egg
+*.whl
+
+# ──────────────────────────────────────────────
+# Node / JavaScript / TypeScript
+# ──────────────────────────────────────────────
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.npm/
+.yarn/
+dist/
+.next/
+.nuxt/
+.output/
+.cache/
+*.tsbuildinfo
+
+# Angular
+.angular/
+
+# ──────────────────────────────────────────────
+# Environment & secrets
+# ──────────────────────────────────────────────
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+secrets/
+
+# ──────────────────────────────────────────────
+# Logs & temp
+# ──────────────────────────────────────────────
+*.log
+*.tmp
+*.swp
+*.bak

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# perfectfit
+
+Body measurement app: customer scans with phone, tailor reads measurements via share code.
+
+## How it works
+
+1. **Customer** opens the Android app, takes two photos (front + side, A-pose), enters their height.
+2. The app sends the photos to the API, which calls the Python measurement service.
+3. A **share code** (e.g. `PF-AB12-CD34`) is returned along with the measurements.
+4. The customer sends the code to their tailor.
+5. **Tailor** opens the web page, enters the share code, and reads the measurements — no in-person meeting needed.
+
+## Monorepo structure
+
+| Folder | What lives here |
+|--------|----------------|
+| `android/` | Kotlin Android app (customer-facing) |
+| `api/` | Spring Boot + Kotlin backend |
+| `measure/` | Python FastAPI measurement service (MediaPipe) |
+| `web/` | Tailor-facing single-page web app |
+| `docs/` | Architecture, decisions, and roadmap |
+
+## Docs
+
+- [Architecture](docs/ARCHITECTURE.md)
+- [Decisions](docs/DECISIONS.md)
+- [Roadmap](docs/ROADMAP.md)
+
+## Development
+
+See each subfolder's `README.md` for local run instructions.

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,9 @@
+# android
+
+Customer-facing Android app (Kotlin, minSdk 26).
+
+Lets the customer take two photos (front + side, A-pose), enter their height, and receive a share code with their measurements.
+
+## Status
+
+Not yet scaffolded — see issue [#12](https://github.com/Erwan-basty/perfectfit/issues/12).

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,17 @@
+# api
+
+Spring Boot + Kotlin backend (Gradle Kotlin DSL).
+
+Accepts scan requests from the Android app, calls the measurement service, stores profiles, and serves them by share code.
+
+## Endpoints (planned)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Health check |
+| `POST` | `/scans` | Submit photos, get share code + measurements |
+| `GET` | `/profiles/{shareCode}` | Retrieve a profile by share code |
+
+## Status
+
+Not yet scaffolded — see issue [#9](https://github.com/Erwan-basty/perfectfit/issues/9).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,70 @@
+# Architecture
+
+## Overview
+
+perfectfit is a monorepo with four services:
+
+```
+┌─────────────────┐        ┌─────────────────┐
+│  Android app    │──────▶ │   Spring Boot   │
+│  (customer)     │  HTTP  │      API        │
+└─────────────────┘        └────────┬────────┘
+                                    │ HTTP
+                           ┌────────▼────────┐
+                           │  Python FastAPI  │
+                           │  measure service │
+                           └─────────────────┘
+
+┌─────────────────┐        ┌─────────────────┐
+│   Web page      │──────▶ │   Spring Boot   │
+│   (tailor)      │  HTTP  │      API        │
+└─────────────────┘        └─────────────────┘
+```
+
+## Services
+
+### `android/` — Android app
+- Language: Kotlin
+- Min SDK: 26
+- Captures two photos (front + side) from the customer
+- Sends them to the API with the customer's height
+- Displays the share code and measurements
+
+### `api/` — Spring Boot API
+- Language: Kotlin, Gradle Kotlin DSL
+- Port: 8080
+- Orchestrates the scan flow: receives photos, calls the measurement service, persists profiles, issues share codes
+- Database: PostgreSQL
+- The measurement logic lives entirely in the `measure/` service — the API never embeds it
+
+### `measure/` — Python measurement service
+- Language: Python, FastAPI
+- Wraps MediaPipe pose estimation
+- Single endpoint: `POST /measure`
+- Intentionally isolated so the measurement engine can be swapped in v2+ without touching the API
+
+### `web/` — Tailor web page
+- Framework TBD (React or Angular)
+- Single page: enter share code → see measurements table
+- No login, no state
+
+## Data flow — scan
+
+1. Customer captures front + side photo on Android
+2. Android POSTs photos + height to `POST /api/scans`
+3. API forwards photos + height to `POST /measure`
+4. Measurement service returns JSON measurements
+5. API generates share code (`PF-XXXX-XXXX`), persists `Profile` in PostgreSQL
+6. API returns `{ shareCode, measurements }` to Android
+7. Customer shares the code with their tailor
+
+## Data flow — tailor lookup
+
+1. Tailor opens web page, enters share code
+2. Web page calls `GET /api/profiles/{shareCode}`
+3. API looks up profile, returns measurements
+4. Web page renders measurements table
+
+## Key design decisions
+
+See [DECISIONS.md](DECISIONS.md) for the full log.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,17 @@
+# Decisions
+
+A log of key technical and product decisions, in chronological order.
+
+---
+
+## 2026-06 — Initial architecture
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Android only for v1, no iOS | Solo developer, faster to ship one platform well |
+| 2 | Measurement logic lives in an isolated Python FastAPI service | Makes the engine swappable in v2+ without touching the API or app |
+| 3 | API talks to the measurement service over HTTP only | Enforces the service boundary; measurement logic never embedded in the API |
+| 4 | v1 targets ±2–4 cm accuracy; no tape-measure calibration step | Calibration contradicts the product promise ("no tape measure needed") |
+| 5 | Share code format: `PF-XXXX-XXXX` | Short enough to type or dictate; human-readable prefix identifies the app |
+| 6 | PostgreSQL for profile storage | Reliable, well-supported in Spring Boot; no exotic requirements in v1 |
+| 7 | Monorepo with four subfolders (`android/`, `api/`, `measure/`, `web/`) | All services in one place; easier for a solo developer to navigate |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# docs
+
+Project documentation.
+
+| File | Contents |
+|------|----------|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | System design, service boundaries, data flow |
+| [DECISIONS.md](DECISIONS.md) | Log of key technical and product decisions |
+| [ROADMAP.md](ROADMAP.md) | Milestones and planned issues |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,36 @@
+# Roadmap
+
+## v1 — End-to-end MVP
+
+Goal: a working end-to-end flow. Customer scans on Android → API → Python measurement service → profile stored with share code → tailor opens share code on web page → sees measurements.
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #7 | chore: set up monorepo skeleton | 🔄 in progress |
+| #8 | chore: bootstrap Python measurement service | ⬜ todo |
+| #9 | chore: bootstrap Spring Boot API | ⬜ todo |
+| #10 | feat: POST /scans endpoint | ⬜ todo |
+| #11 | feat: GET /profiles/{shareCode} endpoint | ⬜ todo |
+| #12 | chore: bootstrap Android project | ⬜ todo |
+| #13 | feat: camera capture screen | ⬜ todo |
+| #14 | feat: two-photo capture flow | ⬜ todo |
+| #15 | feat: A-pose silhouette overlay | ⬜ todo |
+| #16 | feat: send photos to API, show results | ⬜ todo |
+| #17 | feat: tailor web page — look up a profile | ⬜ todo |
+| #18 | chore: deploy v1 to staging environment | ⬜ todo |
+
+## v1.1 — First user feedback
+
+Improvements from real user testing. Issues TBD after v1 ships.
+
+## v2 — Better body finding
+
+AI accuracy improvements: better pose models, SMPL 3D body fitting. The measurement engine is swappable by design.
+
+## v3 — Fit-feedback learning
+
+Learn from fit feedback to improve accuracy over time.
+
+## v4 — Premium accuracy
+
+Sub-centimeter accuracy for bespoke tailoring.

--- a/measure/README.md
+++ b/measure/README.md
@@ -1,0 +1,19 @@
+# measure
+
+Python FastAPI service that wraps the body measurement logic.
+
+Accepts two photos (front + side) and a height in cm. Uses MediaPipe pose landmarks and the Ramanujan ellipse approximation to estimate body measurements. Returns JSON.
+
+## Endpoint (planned)
+
+```
+POST /measure
+  Content-Type: multipart/form-data
+  Fields: front_image (file), side_image (file), height_cm (float)
+
+Response: { "waist_cm": ..., "chest_cm": ..., "hips_cm": ..., ... }
+```
+
+## Status
+
+Not yet scaffolded — see issue [#8](https://github.com/Erwan-basty/perfectfit/issues/8).

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,9 @@
+# web
+
+Tailor-facing single-page web app.
+
+One input for a share code, a Look Up button, and a measurements table. No login required.
+
+## Status
+
+Framework (React or Angular) TBD — decision made at issue [#17](https://github.com/Erwan-basty/perfectfit/issues/17). Not yet scaffolded.


### PR DESCRIPTION
## Summary

- Adds a thorough `.gitignore` covering Kotlin/Gradle, Python, Node/Angular, IntelliJ/Android Studio, VSCode, and macOS (`.DS_Store` and all build outputs)
- Creates the four service folders: `android/`, `api/`, `measure/`, `web/`, plus `docs/`
- Each subfolder has a placeholder `README.md` explaining what lives there and linking to its bootstrap issue
- `docs/ARCHITECTURE.md` — service diagram, data flow for scan and tailor lookup
- `docs/DECISIONS.md` — initial decisions log (7 entries)
- `docs/ROADMAP.md` — milestone overview with v1 issue checklist

## Test plan

- [ ] All folders exist in the repo
- [ ] `.gitignore` entries: verify `.DS_Store`, `build/`, `node_modules/`, `__pycache__/`, `.idea/`, `.gradle/` are all listed
- [ ] No build artefacts or `.DS_Store` files committed

Closes #7