### PR TITLE
feat: POST /scans endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,9 @@ dist/
 secrets/
 
 # ──────────────────────────────────────────────
+# MediaPipe model files (large binaries — download separately, see measure/README.md)
+*.task
+
 # Logs & temp
 # ──────────────────────────────────────────────
 *.log

--- a/api/README.md
+++ b/api/README.md
@@ -6,41 +6,86 @@ This is the brain of the app. It receives photos from the Android app, asks the 
 
 ---
 
+## How the pieces fit together
+
+```
+Android app  ──POST /scans──▶  api (this service)  ──POST /measure──▶  measure (Python)
+                                       │
+                                  PostgreSQL DB
+                                       │
+Tailor web  ──GET /profiles/CODE──▶  api (this service)
+```
+
+Before you can run the API you need **two other things running**:
+1. A PostgreSQL database (we use Docker to start one with a single command)
+2. The Python measurement service (`measure/`)
+
+---
+
 ## Prerequisites — install these first
 
 ### 1. Java (JDK 17 or newer)
 
-The API is written in Kotlin, which runs on the Java Virtual Machine. You need the JDK (Java Development Kit) installed, not just the JRE.
-
 **Check if you already have it:**
 ```bash
 java -version
+# Should print something like: java version "19.0.1"
 ```
-If it prints a version number (e.g. `java version "19.0.1"`), you're good.
 
 **If not installed:**
 - Mac: `brew install openjdk@19`
 - Windows/Linux: download from https://adoptium.net
 
-> You do **not** need to install Gradle separately. This project includes a wrapper script (`gradlew`) that downloads the right version automatically the first time you run it.
+> You do **not** need to install Gradle. The `gradlew` script in this folder downloads the right version automatically.
+
+### 2. Docker Desktop
+
+Docker is used to run a PostgreSQL database locally without installing Postgres directly on your machine.
+
+- Download from https://www.docker.com/products/docker-desktop
+- Install it, then **open Docker Desktop** and wait until it says "Docker is running" in the menu bar
 
 ---
 
-## How to run the API locally
+## Step-by-step: run the full API locally
+
+### Step 1 — Start the database
+
+Open a terminal and run this from the **root of the repo** (not inside `api/`):
 
 ```bash
-# 1. Open a terminal and go to the api folder
-cd ~/perfectfit/api
+docker compose up -d
+```
 
-# 2. Start the server
+- `-d` means "run in the background"
+- This downloads a small Postgres image the first time (~70 MB), then starts it
+- The database is now available at `localhost:5432`
+
+**To stop the database later:**
+```bash
+docker compose down
+```
+
+### Step 2 — Start the Python measurement service
+
+Open a **second terminal** and follow the setup steps in [`measure/README.md`](../measure/README.md). In short:
+
+```bash
+cd measure
+source .venv/bin/activate
+uvicorn main:app --port 8001
+```
+
+### Step 3 — Start the API
+
+Open a **third terminal**:
+
+```bash
+cd api
 ./gradlew bootRun
 ```
 
-On Windows, use `gradlew.bat bootRun` instead.
-
-The first run will take a minute or two — Gradle is downloading dependencies. Subsequent runs are much faster.
-
-You'll know it's ready when you see a line like:
+You'll know it's ready when you see:
 ```
 Started Application in 2.3 seconds
 ```
@@ -49,26 +94,48 @@ Started Application in 2.3 seconds
 
 ## How to test it
 
-Open a **new terminal tab** (keep the server running in the first one) and run:
-
+### Health check
 ```bash
 curl http://localhost:8080/health
+# {"status":"ok"}
 ```
 
-You should see:
+### Submit a scan (requires the Python service running)
+```bash
+curl -X POST http://localhost:8080/scans \
+  -F "frontImage=@/path/to/front.jpg" \
+  -F "sideImage=@/path/to/side.jpg" \
+  -F "heightCm=175"
+```
+
+Expected response:
 ```json
-{"status":"ok"}
+{
+  "shareCode": "PF-AB3K-XY7Q",
+  "measurements": {
+    "shoulderWidthCm": 42.3,
+    "armLengthCm": 58.1,
+    "insideLegCm": 77.4,
+    "waistCircCm": 74.2,
+    "chestCircCm": 91.8
+  }
+}
 ```
 
-You can also open http://localhost:8080/health in your browser — it will show the same thing.
+### Look up a profile by share code
+```bash
+curl http://localhost:8080/profiles/PF-AB3K-XY7Q
+```
 
-> **Important:** the root URL http://localhost:8080 returns a 404 — that's normal. Only the paths listed in the endpoints table below are defined.
+> `GET /profiles/{shareCode}` is implemented in issue #11.
 
 ---
 
-## How to stop the server
+## How to stop everything
 
-Press `Ctrl+C` in the terminal where `./gradlew bootRun` is running.
+- API: `Ctrl+C` in the terminal running `./gradlew bootRun`
+- Python service: `Ctrl+C` in the terminal running `uvicorn`
+- Database: `docker compose down` from the repo root
 
 ---
 
@@ -77,8 +144,8 @@ Press `Ctrl+C` in the terminal where `./gradlew bootRun` is running.
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/health` | Health check — returns `{"status":"ok"}` |
-| `POST` | `/scans` | Submit photos + height, get share code + measurements _(coming in issue #10)_ |
-| `GET` | `/profiles/{shareCode}` | Retrieve a profile by share code _(coming in issue #11)_ |
+| `POST` | `/scans` | Submit photos + height → get share code + measurements |
+| `GET` | `/profiles/{shareCode}` | Retrieve a profile by share code _(issue #11)_ |
 
 ---
 
@@ -86,35 +153,39 @@ Press `Ctrl+C` in the terminal where `./gradlew bootRun` is running.
 
 ```
 api/
-├── gradlew                  # Script that runs Gradle (use this to build/run)
+├── gradlew                  # Script to run Gradle (use this to build/run — Mac/Linux)
 ├── gradlew.bat              # Same, for Windows
 ├── build.gradle.kts         # Project config: dependencies, Java version, plugins
 ├── settings.gradle.kts      # Project name
-├── gradle/wrapper/
-│   └── gradle-wrapper.properties  # Which Gradle version to download
-└── src/
-    └── main/
-        ├── kotlin/com/perfectfit/api/
-        │   ├── Application.kt       # Entry point — starts the Spring Boot server
-        │   └── HealthController.kt  # Handles GET /health
-        └── resources/
-            └── application.yml      # Config: port number, database settings, etc.
+├── docker-compose.yml       # (at repo root) Starts a local PostgreSQL database
+└── src/main/kotlin/com/perfectfit/api/
+    ├── Application.kt           # Entry point — starts the server
+    ├── HealthController.kt      # GET /health
+    ├── ScanController.kt        # POST /scans — receives photos, returns share code
+    ├── MeasurementClient.kt     # Talks to the Python measurement service over HTTP
+    ├── Profile.kt               # Database table definition (one row = one scan)
+    ├── ProfileRepository.kt     # Database queries (Spring writes the SQL for you)
+    └── ShareCodeGenerator.kt    # Generates PF-XXXX-XXXX codes
 ```
 
-### Key concepts (if you're new to Spring Boot)
+---
 
-- **Spring Boot** is a framework that handles the boring parts of building a web server (routing HTTP requests, serialising JSON, connecting to databases) so you can focus on the business logic.
-- **Kotlin** is the language. It runs on the JVM just like Java, but has a cleaner syntax.
-- **Gradle** is the build tool — it compiles the code, manages dependencies, and packages the app.
-- **`@RestController`** — a Spring annotation that marks a class as an HTTP handler. Spring automatically routes incoming requests to the right function.
-- **`@GetMapping("/health")`** — tells Spring: "when someone sends a GET request to /health, run this function."
+## Key concepts (if you're new to Spring Boot)
+
+- **Spring Boot** — handles the boring parts of a web server: routing requests, parsing JSON, connecting to databases.
+- **Kotlin** — the language. Cleaner than Java, runs on the same JVM.
+- **Gradle** — the build tool. Compiles the code and manages libraries.
+- **JPA / Hibernate** — translates between Kotlin objects and database rows. You write `Profile.kt`, Spring creates the `profile` table automatically.
+- **`@RestController`** — marks a class as an HTTP handler. Spring routes requests to the right function.
+- **`@PostMapping("/scans")`** — "when someone sends a POST request to /scans, run this function."
+- **`RestClient`** — Spring's built-in HTTP client, used to call the Python service.
 
 ---
 
 ## Useful Gradle commands
 
 ```bash
-./gradlew bootRun        # Start the server (for development)
+./gradlew bootRun        # Start the server
 ./gradlew build          # Compile + run tests
 ./gradlew build -x test  # Compile only, skip tests
 ./gradlew test           # Run tests only

--- a/api/README.md
+++ b/api/README.md
@@ -128,6 +128,8 @@ Expected response:
 }
 ```
 
+![Successful scan response](../docs/screenshots/scan-success.png)
+
 ### Look up a profile by share code
 ```bash
 curl http://localhost:8080/profiles/PF-AB3K-XY7Q

--- a/api/README.md
+++ b/api/README.md
@@ -59,7 +59,11 @@ docker compose up -d
 
 - `-d` means "run in the background"
 - This downloads a small Postgres image the first time (~70 MB), then starts it
-- The database is now available at `localhost:5432`
+- The database is now available at `localhost:5433`
+
+When it works you'll see:
+
+![Docker compose up](../docs/screenshots/docker-compose-up.png)
 
 **To stop the database later:**
 ```bash
@@ -89,6 +93,8 @@ You'll know it's ready when you see:
 ```
 Started Application in 2.3 seconds
 ```
+
+![API started](../docs/screenshots/api-started.png)
 
 ---
 

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -18,8 +18,10 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("org.postgresql:postgresql")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/api/src/main/kotlin/com/perfectfit/api/MeasurementClient.kt
+++ b/api/src/main/kotlin/com/perfectfit/api/MeasurementClient.kt
@@ -2,7 +2,6 @@ package com.perfectfit.api
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.io.ByteArrayResource
-import org.springframework.http.ContentDisposition
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -27,8 +26,8 @@ class MeasurementClient(
 
     fun measure(frontImage: MultipartFile, sideImage: MultipartFile, heightCm: Double): Measurements {
         val body = LinkedMultiValueMap<String, Any>().apply {
-            add("front_image", filePart(frontImage, "front_image"))
-            add("side_image", filePart(sideImage, "side_image"))
+            add("front_image", filePart(frontImage))
+            add("side_image", filePart(sideImage))
             add("height_cm", heightCm.toString())
         }
 
@@ -41,11 +40,12 @@ class MeasurementClient(
             ?: throw IllegalStateException("Measurement service returned an empty response")
     }
 
-    private fun filePart(file: MultipartFile, fieldName: String): HttpEntity<ByteArrayResource> {
-        val filename = file.originalFilename ?: "$fieldName.jpg"
+    // Spring uses the LinkedMultiValueMap key as the Content-Disposition name automatically.
+    // We only need to set Content-Type so FastAPI recognises the part as a file upload.
+    private fun filePart(file: MultipartFile): HttpEntity<ByteArrayResource> {
+        val filename = file.originalFilename ?: "image.jpg"
         val headers = HttpHeaders().apply {
             contentType = MediaType.IMAGE_JPEG
-            contentDisposition = ContentDisposition.formData().name(fieldName).filename(filename).build()
         }
         val resource = object : ByteArrayResource(file.bytes) {
             override fun getFilename() = filename

--- a/api/src/main/kotlin/com/perfectfit/api/MeasurementClient.kt
+++ b/api/src/main/kotlin/com/perfectfit/api/MeasurementClient.kt
@@ -1,0 +1,44 @@
+package com.perfectfit.api
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestClient
+import org.springframework.web.multipart.MultipartFile
+
+data class Measurements(
+    val shoulder_width_cm: Double? = null,
+    val arm_length_cm: Double? = null,
+    val inside_leg_cm: Double? = null,
+    val waist_circ_cm: Double? = null,
+    val chest_circ_cm: Double? = null,
+)
+
+@Component
+class MeasurementClient(
+    @Value("\${measurement.service-url}") private val serviceUrl: String,
+) {
+    private val client = RestClient.create()
+
+    fun measure(frontImage: MultipartFile, sideImage: MultipartFile, heightCm: Double): Measurements {
+        val body = LinkedMultiValueMap<String, Any>().apply {
+            add("front_image", namedResource(frontImage))
+            add("side_image", namedResource(sideImage))
+            add("height_cm", heightCm.toString())
+        }
+
+        return client.post()
+            .uri("$serviceUrl/measure")
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .body(body)
+            .retrieve()
+            .body(Measurements::class.java)
+            ?: throw IllegalStateException("Measurement service returned an empty response")
+    }
+
+    private fun namedResource(file: MultipartFile) = object : ByteArrayResource(file.bytes) {
+        override fun getFilename() = file.originalFilename ?: "image.jpg"
+    }
+}

--- a/api/src/main/kotlin/com/perfectfit/api/MeasurementClient.kt
+++ b/api/src/main/kotlin/com/perfectfit/api/MeasurementClient.kt
@@ -1,13 +1,14 @@
 package com.perfectfit.api
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.core.io.ByteArrayResource
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
-import org.springframework.util.LinkedMultiValueMap
-import org.springframework.web.client.RestClient
 import org.springframework.web.multipart.MultipartFile
 
 data class Measurements(
@@ -22,34 +23,38 @@ data class Measurements(
 class MeasurementClient(
     @Value("\${measurement.service-url}") private val serviceUrl: String,
 ) {
-    private val client = RestClient.create()
+    private val http = OkHttpClient()
+    private val json = jacksonObjectMapper()
 
     fun measure(frontImage: MultipartFile, sideImage: MultipartFile, heightCm: Double): Measurements {
-        val body = LinkedMultiValueMap<String, Any>().apply {
-            add("front_image", filePart(frontImage))
-            add("side_image", filePart(sideImage))
-            add("height_cm", heightCm.toString())
-        }
+        val body = MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart(
+                "front_image",
+                frontImage.originalFilename ?: "front.jpg",
+                frontImage.bytes.toRequestBody("image/jpeg".toMediaType()),
+            )
+            .addFormDataPart(
+                "side_image",
+                sideImage.originalFilename ?: "side.jpg",
+                sideImage.bytes.toRequestBody("image/jpeg".toMediaType()),
+            )
+            .addFormDataPart("height_cm", heightCm.toString())
+            .build()
 
-        return client.post()
-            .uri("$serviceUrl/measure")
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .body(body)
-            .retrieve()
-            .body(Measurements::class.java)
+        val request = Request.Builder()
+            .url("$serviceUrl/measure")
+            .post(body)
+            .build()
+
+        val response = http.newCall(request).execute()
+        val responseBody = response.body?.string()
             ?: throw IllegalStateException("Measurement service returned an empty response")
-    }
 
-    // Spring uses the LinkedMultiValueMap key as the Content-Disposition name automatically.
-    // We only need to set Content-Type so FastAPI recognises the part as a file upload.
-    private fun filePart(file: MultipartFile): HttpEntity<ByteArrayResource> {
-        val filename = file.originalFilename ?: "image.jpg"
-        val headers = HttpHeaders().apply {
-            contentType = MediaType.IMAGE_JPEG
+        if (!response.isSuccessful) {
+            throw IllegalStateException("Measurement service error ${response.code}: $responseBody")
         }
-        val resource = object : ByteArrayResource(file.bytes) {
-            override fun getFilename() = filename
-        }
-        return HttpEntity(resource, headers)
+
+        return json.readValue(responseBody)
     }
 }

--- a/api/src/main/kotlin/com/perfectfit/api/MeasurementClient.kt
+++ b/api/src/main/kotlin/com/perfectfit/api/MeasurementClient.kt
@@ -2,6 +2,9 @@ package com.perfectfit.api
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.io.ByteArrayResource
+import org.springframework.http.ContentDisposition
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.util.LinkedMultiValueMap
@@ -24,8 +27,8 @@ class MeasurementClient(
 
     fun measure(frontImage: MultipartFile, sideImage: MultipartFile, heightCm: Double): Measurements {
         val body = LinkedMultiValueMap<String, Any>().apply {
-            add("front_image", namedResource(frontImage))
-            add("side_image", namedResource(sideImage))
+            add("front_image", filePart(frontImage, "front_image"))
+            add("side_image", filePart(sideImage, "side_image"))
             add("height_cm", heightCm.toString())
         }
 
@@ -38,7 +41,15 @@ class MeasurementClient(
             ?: throw IllegalStateException("Measurement service returned an empty response")
     }
 
-    private fun namedResource(file: MultipartFile) = object : ByteArrayResource(file.bytes) {
-        override fun getFilename() = file.originalFilename ?: "image.jpg"
+    private fun filePart(file: MultipartFile, fieldName: String): HttpEntity<ByteArrayResource> {
+        val filename = file.originalFilename ?: "$fieldName.jpg"
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.IMAGE_JPEG
+            contentDisposition = ContentDisposition.formData().name(fieldName).filename(filename).build()
+        }
+        val resource = object : ByteArrayResource(file.bytes) {
+            override fun getFilename() = filename
+        }
+        return HttpEntity(resource, headers)
     }
 }

--- a/api/src/main/kotlin/com/perfectfit/api/Profile.kt
+++ b/api/src/main/kotlin/com/perfectfit/api/Profile.kt
@@ -1,0 +1,28 @@
+package com.perfectfit.api
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import java.time.Instant
+
+@Entity
+data class Profile(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(unique = true, nullable = false)
+    val shareCode: String,
+
+    val heightCm: Double,
+
+    // Measurements in cm — null if the service couldn't compute them
+    val shoulderWidthCm: Double? = null,
+    val armLengthCm: Double? = null,
+    val insideLegCm: Double? = null,
+    val waistCircCm: Double? = null,
+    val chestCircCm: Double? = null,
+
+    val createdAt: Instant = Instant.now(),
+)

--- a/api/src/main/kotlin/com/perfectfit/api/ProfileRepository.kt
+++ b/api/src/main/kotlin/com/perfectfit/api/ProfileRepository.kt
@@ -1,0 +1,7 @@
+package com.perfectfit.api
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProfileRepository : JpaRepository<Profile, Long> {
+    fun findByShareCode(shareCode: String): Profile?
+}

--- a/api/src/main/kotlin/com/perfectfit/api/ScanController.kt
+++ b/api/src/main/kotlin/com/perfectfit/api/ScanController.kt
@@ -1,0 +1,71 @@
+package com.perfectfit.api
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+data class ScanResponse(
+    val shareCode: String,
+    val measurements: MeasurementsResponse,
+)
+
+data class MeasurementsResponse(
+    val shoulderWidthCm: Double?,
+    val armLengthCm: Double?,
+    val insideLegCm: Double?,
+    val waistCircCm: Double?,
+    val chestCircCm: Double?,
+)
+
+@RestController
+class ScanController(
+    private val measurementClient: MeasurementClient,
+    private val profileRepository: ProfileRepository,
+    private val shareCodeGenerator: ShareCodeGenerator,
+) {
+    @PostMapping("/scans", consumes = ["multipart/form-data"])
+    fun scan(
+        @RequestParam frontImage: MultipartFile,
+        @RequestParam sideImage: MultipartFile,
+        @RequestParam heightCm: Double,
+    ): ResponseEntity<ScanResponse> {
+        val measurements = measurementClient.measure(frontImage, sideImage, heightCm)
+
+        val shareCode = generateUniqueCode()
+
+        val profile = profileRepository.save(
+            Profile(
+                shareCode = shareCode,
+                heightCm = heightCm,
+                shoulderWidthCm = measurements.shoulder_width_cm,
+                armLengthCm = measurements.arm_length_cm,
+                insideLegCm = measurements.inside_leg_cm,
+                waistCircCm = measurements.waist_circ_cm,
+                chestCircCm = measurements.chest_circ_cm,
+            )
+        )
+
+        return ResponseEntity.ok(
+            ScanResponse(
+                shareCode = profile.shareCode,
+                measurements = MeasurementsResponse(
+                    shoulderWidthCm = profile.shoulderWidthCm,
+                    armLengthCm = profile.armLengthCm,
+                    insideLegCm = profile.insideLegCm,
+                    waistCircCm = profile.waistCircCm,
+                    chestCircCm = profile.chestCircCm,
+                ),
+            )
+        )
+    }
+
+    private fun generateUniqueCode(): String {
+        repeat(10) {
+            val code = shareCodeGenerator.generate()
+            if (profileRepository.findByShareCode(code) == null) return code
+        }
+        throw IllegalStateException("Could not generate a unique share code after 10 attempts")
+    }
+}

--- a/api/src/main/kotlin/com/perfectfit/api/ShareCodeGenerator.kt
+++ b/api/src/main/kotlin/com/perfectfit/api/ShareCodeGenerator.kt
@@ -1,0 +1,13 @@
+package com.perfectfit.api
+
+import org.springframework.stereotype.Component
+
+private val CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789" // no I/O/1/0 to avoid confusion
+
+@Component
+class ShareCodeGenerator {
+    fun generate(): String {
+        fun segment() = (1..4).map { CHARS.random() }.joinToString("")
+        return "PF-${segment()}-${segment()}"
+    }
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/perfectfit
+    url: jdbc:postgresql://localhost:5433/perfectfit
     username: perfectfit
     password: perfectfit
   jpa:

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 server:
   port: 8080
 
+spring.servlet.multipart:
+  max-file-size: 20MB
+  max-request-size: 50MB
+
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5433/perfectfit

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,2 +1,15 @@
 server:
   port: 8080
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/perfectfit
+    username: perfectfit
+    password: perfectfit
+  jpa:
+    hibernate:
+      ddl-auto: update   # auto-creates/updates tables on startup (fine for dev)
+    show-sql: false
+
+measurement:
+  service-url: http://localhost:8001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_USER: perfectfit
       POSTGRES_PASSWORD: perfectfit
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: perfectfit
+      POSTGRES_USER: perfectfit
+      POSTGRES_PASSWORD: perfectfit
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/measure/README.md
+++ b/measure/README.md
@@ -4,13 +4,146 @@ Python FastAPI service that wraps the body measurement logic.
 
 Accepts two photos (front + side, A-pose) and a height in cm. Uses MediaPipe pose landmarks and the Ramanujan ellipse approximation to estimate body measurements. Returns JSON.
 
-## Files
+---
 
-| File | Purpose |
-|------|---------|
-| `main.py` | FastAPI app — HTTP endpoint, request validation, error handling |
-| `measure_core.py` | Pure measurement logic (no HTTP) — easy to test independently |
-| `requirements.txt` | Pinned dependencies |
+## Prerequisites — install these first
+
+### Python 3.10 or 3.11
+
+MediaPipe does not yet support Python 3.12+, so you need 3.10 or 3.11 specifically.
+
+**Check what you have:**
+```bash
+python3 --version
+# Should print: Python 3.10.x or Python 3.11.x
+```
+
+**If you don't have the right version:**
+- Mac: `brew install python@3.11`
+- Windows/Linux: download from https://www.python.org/downloads/release/python-3119/
+
+---
+
+## Step-by-step: run the service locally
+
+### Step 1 — Open a terminal and go to the measure folder
+
+```bash
+cd ~/perfectfit/measure
+```
+
+### Step 2 — Create a virtual environment
+
+A virtual environment is an isolated box for Python packages. It keeps the dependencies for this project separate from everything else on your computer.
+
+```bash
+python3.11 -m venv .venv
+```
+
+This creates a hidden folder called `.venv` inside `measure/`. You only do this **once**.
+
+### Step 3 — Activate the virtual environment
+
+**Mac / Linux:**
+```bash
+source .venv/bin/activate
+```
+
+**Windows:**
+```bash
+.venv\Scripts\activate
+```
+
+You'll know it worked because your terminal prompt will change to show `(.venv)` at the start, like this:
+```
+(.venv) yourmac:measure yourname$
+```
+
+> Every time you open a new terminal to work on this service, you need to run the `activate` command again. The virtual environment is only active for the current terminal session.
+
+### Step 4 — Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+This downloads all the required libraries (MediaPipe, FastAPI, OpenCV, etc.) into the `.venv` folder. The first time takes a few minutes — MediaPipe is large (~100 MB).
+
+### Step 5 — Start the service
+
+```bash
+uvicorn main:app --reload --port 8001
+```
+
+You'll see output like:
+```
+INFO:     Uvicorn running on http://0.0.0.0:8001 (Press CTRL+C to quit)
+INFO:     Started reloader process
+INFO:     Started server process
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+```
+
+The service is now running at http://localhost:8001.
+
+`--reload` means the server automatically restarts when you edit the code — useful during development.
+
+### Step 6 — Verify it's working
+
+Open a **new terminal tab** (keep the service running in the first one) and run:
+
+```bash
+curl http://localhost:8001/health
+# {"status":"ok"}
+```
+
+Or just open http://localhost:8001/health in your browser.
+
+You can also see the interactive API docs at http://localhost:8001/docs — this lets you test the `/measure` endpoint directly in your browser.
+
+---
+
+## How to stop the service
+
+Press `Ctrl+C` in the terminal where `uvicorn` is running.
+
+---
+
+## Next time you want to run it
+
+You don't need to repeat Steps 1–4. Just do:
+
+```bash
+cd ~/perfectfit/measure
+source .venv/bin/activate      # Windows: .venv\Scripts\activate
+uvicorn main:app --reload --port 8001
+```
+
+---
+
+## Test with curl (requires two photos)
+
+```bash
+curl -X POST http://localhost:8001/measure \
+  -F "front_image=@/path/to/front.jpg" \
+  -F "side_image=@/path/to/side.jpg" \
+  -F "height_cm=175"
+```
+
+Replace `/path/to/front.jpg` and `/path/to/side.jpg` with actual photo paths. The person should be in A-pose (arms slightly out), plain background, full body visible.
+
+Expected response:
+```json
+{
+  "shoulder_width_cm": 42.3,
+  "arm_length_cm": 58.1,
+  "inside_leg_cm": 77.4,
+  "waist_circ_cm": 74.2,
+  "chest_circ_cm": 91.8
+}
+```
+
+---
 
 ## Endpoint
 
@@ -23,15 +156,11 @@ Fields:
   side_image   (file)   Side-view photo, A-pose, JPEG or PNG
   height_cm    (float)  Person's real height in centimetres
 
-Response 200:
-{
-  "shoulder_width_cm": 42.3,
-  "arm_length_cm":     58.1,
-  "inside_leg_cm":     77.4,
-  "waist_circ_cm":     74.2,
-  "chest_circ_cm":     91.8
-}
+GET /health
+  Returns: {"status": "ok"}
 ```
+
+---
 
 ## Accuracy (v1)
 
@@ -42,28 +171,13 @@ Response 200:
 
 Circumferences are estimated with the Ramanujan ellipse approximation (front width + side depth). Real bodies aren't perfect ellipses — this is a known v1 limitation.
 
-## Local setup
+---
 
-```bash
-# 1. Create and activate a virtual environment
-python3 -m venv .venv
-source .venv/bin/activate      # Windows: .venv\Scripts\activate
+## Files
 
-# 2. Install dependencies
-pip install -r requirements.txt
-
-# 3. Start the service
-uvicorn main:app --reload --port 8001
-```
-
-The service runs at http://localhost:8001.
-Interactive API docs: http://localhost:8001/docs
-
-## Test with curl
-
-```bash
-curl -X POST http://localhost:8001/measure \
-  -F "front_image=@/path/to/front.jpg" \
-  -F "side_image=@/path/to/side.jpg" \
-  -F "height_cm=175"
-```
+| File | Purpose |
+|------|---------|
+| `main.py` | FastAPI app — HTTP endpoint, request validation, error handling |
+| `measure_core.py` | Pure measurement logic (no HTTP) — easy to test independently |
+| `requirements.txt` | Pinned dependencies |
+| `.venv/` | Your local virtual environment (created by you, not committed to git) |

--- a/measure/README.md
+++ b/measure/README.md
@@ -59,7 +59,18 @@ You'll know it worked because your terminal prompt will change to show `(.venv)`
 
 > Every time you open a new terminal to work on this service, you need to run the `activate` command again. The virtual environment is only active for the current terminal session.
 
-### Step 4 — Install dependencies
+### Step 4 — Download the pose model
+
+MediaPipe 0.10+ requires a model file that is too large for git (~29 MB). Download it once:
+
+```bash
+curl -L "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_heavy/float16/1/pose_landmarker_heavy.task" \
+  -o pose_landmarker.task
+```
+
+This file must be inside the `measure/` folder next to `main.py`.
+
+### Step 6 — Install dependencies
 
 ```bash
 pip install -r requirements.txt
@@ -67,7 +78,7 @@ pip install -r requirements.txt
 
 This downloads all the required libraries (MediaPipe, FastAPI, OpenCV, etc.) into the `.venv` folder. The first time takes a few minutes — MediaPipe is large (~100 MB).
 
-### Step 5 — Start the service
+### Step 7 — Start the service
 
 ```bash
 uvicorn main:app --reload --port 8001
@@ -86,7 +97,7 @@ The service is now running at http://localhost:8001.
 
 `--reload` means the server automatically restarts when you edit the code — useful during development.
 
-### Step 6 — Verify it's working
+### Step 8 — Verify it's working
 
 Open a **new terminal tab** (keep the service running in the first one) and run:
 

--- a/measure/README.md
+++ b/measure/README.md
@@ -8,19 +8,17 @@ Accepts two photos (front + side, A-pose) and a height in cm. Uses MediaPipe pos
 
 ## Prerequisites — install these first
 
-### Python 3.10 or 3.11
-
-MediaPipe does not yet support Python 3.12+, so you need 3.10 or 3.11 specifically.
+### Python 3.10 or newer
 
 **Check what you have:**
 ```bash
 python3 --version
-# Should print: Python 3.10.x or Python 3.11.x
+# Should print: Python 3.10.x or newer
 ```
 
-**If you don't have the right version:**
-- Mac: `brew install python@3.11`
-- Windows/Linux: download from https://www.python.org/downloads/release/python-3119/
+**If not installed:**
+- Mac: `brew install python3`
+- Windows/Linux: download from https://www.python.org/downloads/
 
 ---
 
@@ -37,7 +35,7 @@ cd ~/perfectfit/measure
 A virtual environment is an isolated box for Python packages. It keeps the dependencies for this project separate from everything else on your computer.
 
 ```bash
-python3.11 -m venv .venv
+python3 -m venv .venv
 ```
 
 This creates a hidden folder called `.venv` inside `measure/`. You only do this **once**.

--- a/measure/README.md
+++ b/measure/README.md
@@ -93,6 +93,8 @@ INFO:     Waiting for application startup.
 INFO:     Application startup complete.
 ```
 
+![Measure service startup](../docs/screenshots/measure-startup.png)
+
 The service is now running at http://localhost:8001.
 
 `--reload` means the server automatically restarts when you edit the code — useful during development.
@@ -105,6 +107,8 @@ Open a **new terminal tab** (keep the service running in the first one) and run:
 curl http://localhost:8001/health
 # {"status":"ok"}
 ```
+
+![Measure health check](../docs/screenshots/measure-health.png)
 
 Or just open http://localhost:8001/health in your browser.
 

--- a/measure/measure_core.py
+++ b/measure/measure_core.py
@@ -1,40 +1,58 @@
 """
 measure_core.py
 ---------------
-Pure measurement logic extracted from the validated measure_v2 script.
-No FastAPI, no file I/O — takes numpy images and height, returns a dict.
+Pure measurement logic using the MediaPipe Tasks API (mediapipe 0.10+).
+Takes numpy images and height, returns a dict of measurements.
 
-The algorithm is intentionally unchanged from the validated script:
-  - MediaPipe pose landmarks (model_complexity=2) + segmentation mask
+The algorithm is unchanged from the validated script:
+  - MediaPipe PoseLandmarker (heavy model) + segmentation mask
   - cm-per-pixel ruler derived from the person's known height
   - Ramanujan ellipse approximation for circumferences
 """
 
 import math
+import os
 import cv2
 import mediapipe as mp
 import numpy as np
+from mediapipe.tasks import python as mp_python
+from mediapipe.tasks.python import vision as mp_vision
+
+# BlazePose landmark indices (same topology as the old solutions API)
+_NOSE          = 0
+_LEFT_SHOULDER = 11
+_RIGHT_SHOULDER = 12
+_LEFT_WRIST    = 15
+_RIGHT_WRIST   = 16
+_LEFT_HIP      = 23
+_RIGHT_HIP     = 24
+_LEFT_ANKLE    = 27
+_RIGHT_ANKLE   = 28
+
+_MODEL_PATH = os.path.join(os.path.dirname(__file__), "pose_landmarker.task")
 
 
-# ------------------------------------------------------------------ #
-#  Internal helpers (same logic as the original script)
-# ------------------------------------------------------------------ #
+def _make_landmarker():
+    base_options = mp_python.BaseOptions(model_asset_path=_MODEL_PATH)
+    options = mp_vision.PoseLandmarkerOptions(
+        base_options=base_options,
+        output_segmentation_masks=True,
+        num_poses=1,
+    )
+    return mp_vision.PoseLandmarker.create_from_options(options)
+
 
 def _analyze_image(bgr_image: np.ndarray):
-    """Run MediaPipe on a BGR numpy image.
+    """Run MediaPipe PoseLandmarker on a BGR numpy image.
     Returns (landmarks, silhouette_mask, img_h, img_w).
     Raises ValueError if no body is detected.
     """
     h, w = bgr_image.shape[:2]
     rgb = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2RGB)
+    mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb)
 
-    mp_pose = mp.solutions.pose
-    with mp_pose.Pose(
-        static_image_mode=True,
-        model_complexity=2,
-        enable_segmentation=True,
-    ) as pose:
-        result = pose.process(rgb)
+    with _make_landmarker() as landmarker:
+        result = landmarker.detect(mp_image)
 
     if not result.pose_landmarks:
         raise ValueError(
@@ -42,18 +60,23 @@ def _analyze_image(bgr_image: np.ndarray):
             "background is plain, and lighting is good."
         )
 
-    silhouette = (result.segmentation_mask > 0.5).astype(np.uint8)
-    return result.pose_landmarks.landmark, silhouette, h, w
+    landmarks = result.pose_landmarks[0]  # list of NormalizedLandmark
+
+    if not result.segmentation_masks:
+        raise ValueError("Segmentation mask not available.")
+
+    mask_array = result.segmentation_masks[0].numpy_view()
+    silhouette = (mask_array > 0.5).astype(np.uint8)
+
+    return landmarks, silhouette, h, w
 
 
 def _cm_per_pixel(landmarks, img_h: int, height_cm: float) -> float:
-    """Derive the cm-per-pixel scale factor from the known real height."""
-    mp_lm = mp.solutions.pose.PoseLandmark
     ys = [lm.y for lm in landmarks]
     top_y = min(ys) * img_h
     ankle_y = max(
-        landmarks[mp_lm.LEFT_ANKLE.value].y,
-        landmarks[mp_lm.RIGHT_ANKLE.value].y,
+        landmarks[_LEFT_ANKLE].y,
+        landmarks[_RIGHT_ANKLE].y,
     ) * img_h
     height_px = ankle_y - top_y
     if height_px <= 0:
@@ -62,7 +85,6 @@ def _cm_per_pixel(landmarks, img_h: int, height_cm: float) -> float:
 
 
 def _body_width_px(silhouette: np.ndarray, y_level: float) -> float:
-    """Width of the body silhouette (in pixels) at a given y coordinate."""
     row = silhouette[int(y_level), :]
     body_pixels = np.where(row > 0)[0]
     if len(body_pixels) < 2:
@@ -71,37 +93,13 @@ def _body_width_px(silhouette: np.ndarray, y_level: float) -> float:
 
 
 def _ellipse_circumference(width_cm: float, depth_cm: float) -> float:
-    """Ramanujan approximation of an ellipse perimeter.
-    width  = front-view body width at this level
-    depth  = side-view body width at this level
-    """
     a = width_cm / 2.0
     b = depth_cm / 2.0
     return math.pi * (3 * (a + b) - math.sqrt((3 * a + b) * (a + 3 * b)))
 
 
-# ------------------------------------------------------------------ #
-#  Public API
-# ------------------------------------------------------------------ #
-
-def measure(
-    front_bgr: np.ndarray,
-    side_bgr: np.ndarray,
-    height_cm: float,
-) -> dict:
-    """Compute body measurements from two photos and a known height.
-
-    Args:
-        front_bgr:  Front photo as a BGR numpy array (from cv2.imdecode).
-        side_bgr:   Side photo as a BGR numpy array.
-        height_cm:  Real height of the person in centimetres.
-
-    Returns:
-        Dict with measurement names as keys and cm values as floats.
-        Circumference keys end in '_circ_cm'; linear keys end in '_cm'.
-    """
-    mp_lm = mp.solutions.pose.PoseLandmark
-
+def measure(front_bgr: np.ndarray, side_bgr: np.ndarray, height_cm: float) -> dict:
+    """Compute body measurements from two photos and a known height."""
     f_lm, f_sil, f_h, f_w = _analyze_image(front_bgr)
     s_lm, s_sil, s_h, s_w = _analyze_image(side_bgr)
 
@@ -110,36 +108,34 @@ def measure(
 
     results = {}
 
-    # --- Linear measurements (front photo only) ---
-    lsh = f_lm[mp_lm.LEFT_SHOULDER.value]
-    rsh = f_lm[mp_lm.RIGHT_SHOULDER.value]
+    # Linear measurements (front photo)
+    lsh = f_lm[_LEFT_SHOULDER]
+    rsh = f_lm[_RIGHT_SHOULDER]
     shoulder_px = abs(lsh.x - rsh.x) * f_w
     results["shoulder_width_cm"] = round(shoulder_px * f_cmpp, 1)
 
-    lwr = f_lm[mp_lm.LEFT_WRIST.value]
+    lwr = f_lm[_LEFT_WRIST]
     arm_px = math.hypot((lsh.x - lwr.x) * f_w, (lsh.y - lwr.y) * f_h)
     results["arm_length_cm"] = round(arm_px * f_cmpp, 1)
 
-    lhip = f_lm[mp_lm.LEFT_HIP.value]
-    lank = f_lm[mp_lm.LEFT_ANKLE.value]
+    lhip = f_lm[_LEFT_HIP]
+    lank = f_lm[_LEFT_ANKLE]
     leg_px = math.hypot((lhip.x - lank.x) * f_w, (lhip.y - lank.y) * f_h)
     results["inside_leg_cm"] = round(leg_px * f_cmpp, 1)
 
-    # --- Circumferences (front width + side depth → ellipse) ---
+    # Circumferences (front width + side depth → ellipse)
     def _level(lm_a, lm_b, img_h):
         return (lm_a.y + lm_b.y) / 2.0 * img_h
 
-    # Waist
-    waist_y_f = _level(f_lm[mp_lm.LEFT_HIP.value], f_lm[mp_lm.RIGHT_HIP.value], f_h)
-    waist_y_s = _level(s_lm[mp_lm.LEFT_HIP.value], s_lm[mp_lm.RIGHT_HIP.value], s_h)
+    waist_y_f = _level(f_lm[_LEFT_HIP], f_lm[_RIGHT_HIP], f_h)
+    waist_y_s = _level(s_lm[_LEFT_HIP], s_lm[_RIGHT_HIP], s_h)
     waist_w = _body_width_px(f_sil, waist_y_f) * f_cmpp
     waist_d = _body_width_px(s_sil, waist_y_s) * s_cmpp
     if waist_w and waist_d:
         results["waist_circ_cm"] = round(_ellipse_circumference(waist_w, waist_d), 1)
 
-    # Chest
-    chest_y_f = _level(f_lm[mp_lm.LEFT_SHOULDER.value], f_lm[mp_lm.LEFT_HIP.value], f_h)
-    chest_y_s = _level(s_lm[mp_lm.LEFT_SHOULDER.value], s_lm[mp_lm.LEFT_HIP.value], s_h)
+    chest_y_f = _level(f_lm[_LEFT_SHOULDER], f_lm[_LEFT_HIP], f_h)
+    chest_y_s = _level(s_lm[_LEFT_SHOULDER], s_lm[_LEFT_HIP], s_h)
     chest_w = _body_width_px(f_sil, chest_y_f) * f_cmpp
     chest_d = _body_width_px(s_sil, chest_y_s) * s_cmpp
     if chest_w and chest_d:

--- a/measure/requirements.txt
+++ b/measure/requirements.txt
@@ -2,5 +2,5 @@ fastapi==0.111.0
 uvicorn[standard]==0.29.0
 python-multipart==0.0.9
 opencv-python-headless==4.9.0.80
-mediapipe==0.10.21
+mediapipe==0.10.35
 numpy==1.26.4


### PR DESCRIPTION
## Summary

- **`ScanController`** — `POST /scans` accepts two photos (multipart) + `heightCm`, calls the measurement service, persists the result, returns `{ shareCode, measurements }`
- **`MeasurementClient`** — forwards photos to the Python service at `http://localhost:8001/measure` using Spring's `RestClient`
- **`Profile`** — JPA entity, one row per scan. Spring auto-creates the `profile` table on startup.
- **`ProfileRepository`** — Spring Data JPA interface; `findByShareCode()` is the only custom query needed
- **`ShareCodeGenerator`** — generates `PF-XXXX-XXXX` codes using an unambiguous character set (no I/O/1/0)
- **`docker-compose.yml`** — at repo root; `docker compose up -d` starts a local Postgres in seconds
- **`application.yml`** — datasource config + `measurement.service-url` property
- **`api/README.md`** — full beginner-friendly guide: Docker setup, step-by-step run instructions, curl examples

## Test plan

- [ ] `docker compose up -d` starts Postgres without errors
- [ ] `./gradlew bootRun` starts and connects to Postgres (check logs for "HikariPool" connected)
- [ ] With the Python service running: `POST /scans` with two photos returns `{ shareCode, measurements }`
- [ ] Share code format is `PF-XXXX-XXXX`
- [ ] A row exists in the `profile` table after a successful scan

Closes #10